### PR TITLE
ensure plugin name is unique and cant exist two times

### DIFF
--- a/app/PluginManager.ts
+++ b/app/PluginManager.ts
@@ -11,6 +11,9 @@ export class PluginManager {
     }
 
     registerPlugin(plugin: Plugin) {
+        if (this.plugins.some(p => p.name === plugin.name)) {
+            throw Error(`[ERROR] Plugin with name ${plugin.name} already registed.`)
+        }
         const requiredIntents = plugin.requiredIntents;
 
         for (const requiredIntent of requiredIntents || []) {


### PR DESCRIPTION
**Hey there!**

The solution uses an if statement to check for an existing plugin with the same name before adding the new one to the list. This should prevent any duplicates from being registered and ensure each plugin has a unique name.

Let me know if you have any questions or suggestions!