### PR TITLE
Prevent adding intents after the run method has been called

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -13,6 +13,7 @@ export class GrotCore {
   private database: Database;
   private pluginManager: PluginManager;
   private actionRegistry: ActionRegistry;
+  private started: boolean = false;
 
   public constructor(options?: GrotOptions) {
     this.intents = new Set<GatewayIntentBits>(options?.intents);
@@ -22,6 +23,9 @@ export class GrotCore {
   }
 
   public addIntent(intent: GatewayIntentBits) {
+    if (this.started) {
+      throw Error(`[ERROR] You cannot add intents after calling the run() method`)
+    }
     this.intents.add(intent)
   }
 
@@ -112,5 +116,6 @@ export class GrotCore {
     this.setupInteractionHandler();
 
     this.client.login(process.env.DISCORD_TOKEN);
+    this.started = true;
   }
 }


### PR DESCRIPTION
This PR fixes an issue where intents could still be added after the run method had already been executed. Since intents are meant to be finalized before execution, allowing modifications afterward could lead to unexpected behavior.

The update adds a safeguard to prevent new intents from being registered once run has been called, ensuring a more predictable and stable execution flow.